### PR TITLE
Add a reload button in the About screen

### DIFF
--- a/src/AboutView.js
+++ b/src/AboutView.js
@@ -71,6 +71,7 @@ class AboutView extends Component {
         <p>A minimalistic Domoticz dashboard</p>
         <p>Color theme: <ThemeSelector themes={this.props.themes} currentTheme={this.props.appState && this.props.appState.themeId} onThemeChange={this.props.onThemeChange} /></p>
         <p>This is a work in progress! Documentation is available on the project's <a href="https://github.com/t0mg/reacticz" target="_blank">GitHub repository</a>.</p>
+        <p><a href=".">Reload</a></p>
         <section>
           <h2>Export settings</h2>
           <p>To clone your settings to another device, share the URL below.</p>


### PR DESCRIPTION
Add a reload button in the about screen. This can be used to reload the page on iOS when the app is set to full screen. In that case there is no way to reload the page and due to caching changes will not always be visible.

![about](https://cloud.githubusercontent.com/assets/11230573/22400797/0d86b146-e5bf-11e6-9c75-d01f542446a6.png)
