### PR TITLE
Use url type for url inputs

### DIFF
--- a/src/SettingsView.css
+++ b/src/SettingsView.css
@@ -23,7 +23,7 @@
   align-items: center
 }
 
-.SettingsView input[type=text], input[type=password]  {
+.SettingsView input[type=text], input[type=password], input[type=url]  {
   display: block;
   width: 100%;
   max-width: 500px;

--- a/src/SettingsView.js
+++ b/src/SettingsView.js
@@ -97,7 +97,7 @@ class SettingsView extends Component {
           <h3>MQTT {this.props.config && this.props.config.mqttBrokerUrl && mqttOk}</h3>
           <label>
             Broker URL:
-            <input type="text" value={this.state.mqttBrokerUrl} name="mqttBrokerUrl" placeholder="ws://mqtt-broker:port" onChange={this.handleChange} />
+            <input type="url" value={this.state.mqttBrokerUrl} name="mqttBrokerUrl" placeholder="ws://mqtt-broker:port" onChange={this.handleChange} />
           </label>
           <label>
             <input type="checkbox" name="mqttAuthChecked" onChange={this.handleChange}
@@ -109,7 +109,7 @@ class SettingsView extends Component {
           <h3>Domoticz {this.props.config && this.props.config.domoticzUrl && domoticzOk}</h3>
           <label>
             Server URL:
-            <input type="text" value={this.state.domoticzUrl} name="domoticzUrl" placeholder="http://domoticz-server:port" onChange={this.handleChange} />
+            <input type="url" value={this.state.domoticzUrl} name="domoticzUrl" placeholder="http://domoticz-server:port" onChange={this.handleChange} />
           </label>
           <label>
             <input type="checkbox" name="domoticzAuthChecked" onChange={this.handleChange}

--- a/src/widgets/SwitchDimmer.js
+++ b/src/widgets/SwitchDimmer.js
@@ -21,6 +21,9 @@ class SwitchDimmer extends Component {
   }
 
   onClick = (event) => {
+    if (this.props.readOnly) {
+      return
+    }
     var rect = this.touchTarget.getBoundingClientRect();
     let value = (event.pageX - rect.left) / rect.width;
     // Make off and max slightly larger touch targets.


### PR DESCRIPTION
Use url type for url inputs:
- fallback to text if not supported
- pattern matching by default