### PR TITLE
Smoke sensor

### DIFF
--- a/src/widgets/DeviceWidget.js
+++ b/src/widgets/DeviceWidget.js
@@ -82,7 +82,7 @@ class DeviceWidget extends Component {
         return <MotionSensorWidget label={device.name} value={Number(device.nvalue)}
             {...this.props} />
       case 'On/Off' :
-        if (device.stype === 'KD101 smoke detector' || device.description.includes('Reacticz: smoke sensor')) {
+        if (device.stype === 'KD101 smoke detector' || (typeof device.description === 'string' && device.description.includes('Reacticz: smoke sensor'))) {
           return <SmokeSensorWidget idx={device.idx} label={device.name}
               value={device.nvalue} {...this.props} />;
         }

--- a/src/widgets/DeviceWidget.js
+++ b/src/widgets/DeviceWidget.js
@@ -82,7 +82,7 @@ class DeviceWidget extends Component {
         return <MotionSensorWidget label={device.name} value={Number(device.nvalue)}
             {...this.props} />
       case 'On/Off' :
-        if (device.stype === 'KD101 smoke detector') {
+        if (device.stype === 'KD101 smoke detector' || device.description.includes('Reacticz: smoke sensor')) {
           return <SmokeSensorWidget idx={device.idx} label={device.name}
               value={device.nvalue} {...this.props} />;
         }


### PR DESCRIPTION
Use description field in smoke sensor to distuingish it from on On/Off switch. This can be used for smoke sensors which only have On/Off switch characteristics in Domoticz, such as a Fibaro FGSD002.

If you add "Reacticz: smoke sensor" to the description field in Domoticz,  it will show as a smoke sensor on the Reacticz dashboard in stead of an On/Off switch.

See https://github.com/t0mg/reacticz/pull/81#issuecomment-279186266.

You have to be on Domoticz version >= 3.6 to make this work. In the latest stable version 3.5877 the MQTT output doesn't contain the description field, which is needed for this to work.